### PR TITLE
Stringification issue with Dancer::Plugin::Passphrase

### DIFF
--- a/lib/Dancer/Plugin/Passphrase.pm
+++ b/lib/Dancer/Plugin/Passphrase.pm
@@ -65,6 +65,7 @@ our $VERSION = '2.0.0';
 # of the object unless we are calling a method on it
 use overload (
     '""' => 'rfc2307',
+    fallback => 1,
 );
 
 register passphrase => \&passphrase;


### PR DESCRIPTION
I'm writing a little application that needs to create and store usernames and passwords. In searching for the current best practice for storing passwords in a DB I came across Dancer::Plugin::Passphrase[1] and have been trying to use that.

But I get a problem when I try to save the new record. In my route handler I have code like this:

```
my $user = $user_rs->create({
    username => param('username'),
    email => param('email'),
    # password => param('password'),
    password => passphrase(param('password'))->generate_hash,
});

template 'registered', { user => $user };
```

This example is copied wholesale from the plugin's synopsis.

I get the following runtime error:

Operation "ne": no method found,
    left argument in overloaded package Dancer::Plugin::Passphrase,
    right argument in overloaded package Dancer::Plugin::Passphrase at /usr/share/perl5/vendor_perl/DBIx/Class/Row.pm line 356, <DATA> line 16.

/usr/share/perl5/vendor_perl/DBIx/Class/Row.pm around line 356

353   );
354 
355   for (keys %$returned_cols) {
356     $self->store_column($_, $returned_cols->{$_})
357       # this ensures we fire store_column only once
358       # (some asshats like overriding it)
359       if (

But the record is stored in the database correctly.

As you'll see from my code snippet above, I've experimented with saving plain-text passwords and that works exactly as expected. So the problem is definitely in the use of this plugin.

My change fixes this error by forcing Perl to call rfc2307() to stringify the object in cases like these.

Cheers,

Dave...
